### PR TITLE
Initial checkin nuttx website github action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [closed] 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.merged == true
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --prune --unshallow
+
+    - name: Intall tools  
+      run: |
+        sudo apt-get -y install rubygems ruby-dev zlib1g-dev
+        sudo gem install bundler github-pages jekyll
+        
+    - name: Run publish.sh
+      run: | 
+        sudo ./publish.sh
+        git push origin asf-site:asf-site


### PR DESCRIPTION
Nuttx website github action workflow:
1. Checkout nuttx website
2. Install essential tools
3. Run publish.sh and push asf-site branch

Signed-off-by: liuhaitao <liuhaitao@xiaomi.com>